### PR TITLE
FIX: Remove variable injection from theme setting

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -54,7 +54,13 @@ $i: !important;
 
 $v-font-weight: 300 !default;
 $v-font-size: 1.1em !default;
-$v-theme-background: url(#{$theme_background}) !default;
+$v-theme-background: null;
+@if ($theme_background == "") {
+    $v-theme-background: url(#{$vincent_background}) !default;
+} @else {
+    $v-theme-background: url(#{$theme_background}) !default;    
+}
+
 $v-hue: 0 !default;
 $v-saturation: -25 !default;
 $v-lightness: 0 !default;

--- a/settings.yml
+++ b/settings.yml
@@ -1,5 +1,5 @@
 theme_background:
-  default: "#{$vincent-background}"
+  default: ""
   description:
     en: If you wish to change the default background add the url of the new background above.
 dark_background_overlay:


### PR DESCRIPTION
This is currently making use of a bug in core, which will soon be patched. It should not be possible to put executable sass code into a theme variable.